### PR TITLE
Import gettext_lazy for translation instead of ugettext_lazy

### DIFF
--- a/sage_stream/models.py
+++ b/sage_stream/models.py
@@ -1,6 +1,6 @@
 from django.conf import settings
 from django.db import models
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 class WatchLog(models.Model):
     """Stream watch log"""


### PR DESCRIPTION
Replace 'from django.utils.translation import ugettext_lazy as _' to 'from django.utils.translation import gettext_lazy as _' to support django 4 in line 3 of models.py