### PR TITLE
Fixing video path and configuring to django 4

### DIFF
--- a/sage_stream/api/views.py
+++ b/sage_stream/api/views.py
@@ -27,7 +27,8 @@ class VideoStreamAPIView(APIView):
         video_path = request.GET.get(path_key)
         range_header = request.META.get('HTTP_RANGE', '').strip()
         range_re = re.compile(range_re_pattern, re.I)
-        video_path = video_path.replace(media_url, media_dir)
+        if not (media_url == '/' or media_dir == ''):
+            video_path = video_path.replace(media_url, media_dir)
         video_path = os.path.join(django_settings.BASE_DIR, video_path)
 
         # log

--- a/sage_stream/models.py
+++ b/sage_stream/models.py
@@ -1,6 +1,6 @@
 from django.conf import settings
 from django.db import models
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 class WatchLog(models.Model):
     """Stream watch log"""


### PR DESCRIPTION
Simply adding a check condition if _MEDIA_URL_ and _MEDIA_ROOT_ are not set in the **settings.py** so that the video path is not changed to something that doesn't exist when given the absolute path
Also configured it to use  with Django 4.