### PR TITLE
Removed Deprecated Module Import On Models

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 Django>=3.2.3
 djangorestframework>=3.12.4
 setuptools>=56.2.0
+boto3>=1.18.67

--- a/sage_stream/api/views.py
+++ b/sage_stream/api/views.py
@@ -1,46 +1,64 @@
 import re
-import os
+import boto3
 from django.conf import settings as django_settings
 from rest_framework.views import APIView
-
-from sage_stream import settings
+from django.http import StreamingHttpResponse
+from sage_stream import settings as sage_settings
 from sage_stream.utils.log_services import log_watch_request, get_request_ip
-from sage_stream.utils.stream_services import get_streaming_response
-
 
 class VideoStreamAPIView(APIView):
-    """return StreamingHTTPResponse"""
-
-    permission_classes = settings.STREAM_DEFAULT_PERMISSION_CLASSES
+    permission_classes = sage_settings.STREAM_DEFAULT_PERMISSION_CLASSES
 
     def get(self, request, *args, **kwargs):
-        """get range header & create streaming response"""
-        # initialize parameters
-        max_load_volume = settings.STREAM_MAX_LOAD_VOLUME
-        path_key = settings.STREAM_DEFAULT_VIDEO_PATH_URL_VAR
-        range_re_pattern = settings.STREAM_RANGE_HEADER_REGEX_PATTERN
-        log_enabled = settings.STREAM_WATCH_LOG_ENABLED
-        media_dir = django_settings.MEDIA_ROOT
-        media_url = django_settings.MEDIA_URL
+       
+        max_load_volume = sage_settings.STREAM_MAX_LOAD_VOLUME
+        path_key = sage_settings.STREAM_DEFAULT_VIDEO_PATH_URL_VAR
+        range_re_pattern = sage_settings.STREAM_RANGE_HEADER_REGEX_PATTERN
+        log_enabled = sage_settings.STREAM_WATCH_LOG_ENABLED
 
-        # get video path & range header
-        video_path = request.GET.get(path_key)
+
+        s3_key = request.GET.get(path_key)
+
         range_header = request.META.get('HTTP_RANGE', '').strip()
         range_re = re.compile(range_re_pattern, re.I)
-        video_path = video_path.replace(media_url, media_dir)
-        video_path = os.path.join(django_settings.BASE_DIR, video_path)
 
-        # log
         if log_enabled:
             ip = get_request_ip(request)
-            log_watch_request(video_path, request.user.is_authenticated, ip, request.user)
+            log_watch_request(s3_key, request.user.is_authenticated, ip, request.user)
 
-        # create response
-        response = get_streaming_response(
-            path=video_path,
-            range_header=range_header,
-            range_re=range_re,
-            max_load_volume=max_load_volume,  # the maximum volume of the response body
+      
+        s3_client = boto3.client(
+            's3',
+            endpoint_url=django_settings.AWS_S3_ENDPOINT_URL,
+            aws_access_key_id=django_settings.AWS_ACCESS_KEY_ID,
+            aws_secret_access_key=django_settings.AWS_SECRET_ACCESS_KEY,
+            region_name=django_settings.AWS_S3_REGION_NAME,
         )
+
+        s3_range = None
+        if range_header:
+            match = range_re.match(range_header)
+            if match:
+                start, end = match.groups()
+                s3_range = f"bytes={start}-{end or ''}"
+
+        s3_params = {"Bucket": django_settings.AWS_STORAGE_BUCKET_NAME, "Key": s3_key}
+        if s3_range:
+            s3_params["Range"] = s3_range
+
+        s3_response = s3_client.get_object(**s3_params)
+
+        # Build streaming HTTP response
+        response = StreamingHttpResponse(
+            streaming_content=s3_response["Body"].iter_chunks(chunk_size=8192),
+            status=206 if s3_range else 200,
+            content_type=s3_response["ContentType"]
+        )
+
+        response["Accept-Ranges"] = "bytes"
+        if "ContentRange" in s3_response:
+            response["Content-Range"] = s3_response["ContentRange"]
+        if "ContentLength" in s3_response:
+            response["Content-Length"] = str(s3_response["ContentLength"])
 
         return response

--- a/sage_stream/models.py
+++ b/sage_stream/models.py
@@ -1,6 +1,6 @@
 from django.conf import settings
 from django.db import models
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 class WatchLog(models.Model):
     """Stream watch log"""


### PR DESCRIPTION
There is an error "ImportError: cannot import name ‘ugettext_lazy’ from ‘django.utils.translation’"
Since the module is deprecated since python 2.2, there was need to change to the gettext_lazy module on "models.py"